### PR TITLE
Fix image lazy loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ def main():
             row = []
             if is_scraping_images:
                 img_tag = container.find("img")
-                row.append(img_tag["src"] if img_tag else "N/A")
+                row.append((img_tag.attrs.get("data-lazy-src") or img_tag.attrs.get("src")) if img_tag else "N/A")
 
             row += [
                 song,


### PR DESCRIPTION
Only the first few images are actually loaded into the src of the images on page load, so this change makes the script check in the data-lazy-src also to make sure that most images aren't palceholders.

Do you remember me? :) Love the changes you've made since then!